### PR TITLE
Add box-sizing property to navigation elements

### DIFF
--- a/lib/Styles/less/DistanceLegend.less
+++ b/lib/Styles/less/DistanceLegend.less
@@ -5,6 +5,7 @@
     height: 30px;
     width: 125px;
     border: 1px solid rgba(255,255,255,0.1);
+    box-sizing: content-box;
 }
 
 .distance-legend-label {

--- a/lib/Styles/less/Navigation.less
+++ b/lib/Styles/less/Navigation.less
@@ -84,6 +84,7 @@
     height: 44px;
     border-radius: 44px;
     border: 12px solid @floating-background-color;
+    box-sizing: content-box;
 }
 
 .compass-gyro {
@@ -108,6 +109,7 @@
     border-radius: 33px;
     background-color: @floating-background-color;
     border: 1px solid rgba(255,255,255,0.2);
+    box-sizing: content-box;
 }
 
 .compass-gyro-background:hover + .compass-gyro {

--- a/lib/Styles/less/Navigation.less
+++ b/lib/Styles/less/Navigation.less
@@ -52,6 +52,7 @@
     fill: fade(@floating-text-color, 80%);
     padding-top: 6px;
     padding-bottom: 6px;
+    box-sizing: content-box;
 }
 
 


### PR DESCRIPTION
In our css we were using bootstrap and some other libraries that were setting box-sizing to 'border-box' and that threw off the positioning of the compass backgrounds and some of the other elements.  But this fixes it all back up again.

Thanks for creating this, @alberto-acevedo !