### PR TITLE
Fixed 2 bugs occured in 2D and Columbus mode

### DIFF
--- a/lib/Styles/less/Navigation.less
+++ b/lib/Styles/less/Navigation.less
@@ -67,6 +67,7 @@
     top: 100px;
     width: @compass-diameter;
     height: @compass-diameter;
+    overflow: hidden;
 }
 
 .compass-outer-ring {

--- a/lib/ViewModels/NavigationViewModel.js
+++ b/lib/ViewModels/NavigationViewModel.js
@@ -190,7 +190,6 @@ define('NavigationViewModel', ['Knockout', 'loadView', 'inherit', 'ResetViewNavi
     var newTransformScratch = new Cesium.Matrix4();
     var centerScratch = new Cesium.Cartesian3();
     var windowPositionScratch = new Cesium.Cartesian2();
-    var pickRayScratch = new Cesium.Ray();
 
     NavigationViewModel.prototype.handleDoubleClick = function (viewModel, e) {
         var scene = this.terria.scene;
@@ -199,13 +198,14 @@ define('NavigationViewModel', ['Knockout', 'loadView', 'inherit', 'ResetViewNavi
         var windowPosition = windowPositionScratch;
         windowPosition.x = scene.canvas.clientWidth / 2;
         windowPosition.y = scene.canvas.clientHeight / 2;
-        var ray = camera.getPickRay(windowPosition, pickRayScratch);
-
-        var center = scene.globe.pick(ray, scene, centerScratch);
+        
+        var center = camera.pickEllipsoid(windowPosition, scene.globe.ellipsoid, centerScratch);
+        
         if (!Cesium.defined(center)) {
             // Globe is barely visible, so reset to home view.
-
-            this.terria.zoomTo(this.terria.homeView, 1.5);
+            camera.flyTo({
+                destination: Cesium.Camera.DEFAULT_VIEW_RECTANGLE
+            });
             return;
         }
 
@@ -250,9 +250,9 @@ define('NavigationViewModel', ['Knockout', 'loadView', 'inherit', 'ResetViewNavi
         var windowPosition = windowPositionScratch;
         windowPosition.x = scene.canvas.clientWidth / 2;
         windowPosition.y = scene.canvas.clientHeight / 2;
-        var ray = camera.getPickRay(windowPosition, pickRayScratch);
 
-        var center = scene.globe.pick(ray, scene, centerScratch);
+        var center = camera.pickEllipsoid(windowPosition, scene.globe.ellipsoid, centerScratch);
+
         if (!Cesium.defined(center)) {
             viewModel.orbitFrame = Cesium.Transforms.eastNorthUpToFixedFrame(camera.positionWC, Cesium.Ellipsoid.WGS84, newTransformScratch);
             viewModel.orbitIsLook = true;
@@ -354,9 +354,9 @@ define('NavigationViewModel', ['Knockout', 'loadView', 'inherit', 'ResetViewNavi
         var windowPosition = windowPositionScratch;
         windowPosition.x = scene.canvas.clientWidth / 2;
         windowPosition.y = scene.canvas.clientHeight / 2;
-        var ray = camera.getPickRay(windowPosition, pickRayScratch);
 
-        var viewCenter = scene.globe.pick(ray, scene, centerScratch);
+        var viewCenter = camera.pickEllipsoid(windowPosition, scene.globe.ellipsoid, centerScratch);
+
         if (!Cesium.defined(viewCenter)) {
             viewModel.rotateFrame = Cesium.Transforms.eastNorthUpToFixedFrame(camera.positionWC, Cesium.Ellipsoid.WGS84, newTransformScratch);
             viewModel.rotateIsLook = true;


### PR DESCRIPTION
Bug fixed: determining center did not work when in 2D or Columbus mode. This can be achieved by using camera.pickEllipsoid.

Bug fixed: If no center could be found (e.g. when in Columbus mode and the mid-ray does not intersect the map) then Camera.flyTo is used. Previously Camera.zoomTo was used but with wrong arguments which resulted in a DeveloperError.